### PR TITLE
Build on Go 1.15+ only

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.15.x, ^1]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     env:


### PR DESCRIPTION
This will allow things like #18 and we could also replace `pkg/erros` with plain `fmt.Errorf`. 

We only release on Go 1.15 anyway, so this seems fair to me 🤔 