### PR TITLE
Fix issues with mismatched time zones on encryption keys

### DIFF
--- a/client/crypt.go
+++ b/client/crypt.go
@@ -102,14 +102,12 @@ func (cc *Client) cryptCheck() error {
 		if err != nil {
 			return err
 		}
-		now := time.Now()
 		k := base64.StdEncoding.EncodeToString(b)
 		ek := &charm.EncryptKey{}
 		ek.PublicKey = auth.PublicKey
 		ek.ID = uuid.New().String()
 		ek.Key = k
-		ek.CreatedAt = &now
-		err = cc.addEncryptKey(ek.PublicKey, ek.ID, ek.Key, ek.CreatedAt)
+		err = cc.addEncryptKey(ek.PublicKey, ek.ID, ek.Key, nil)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/bubbletea v0.19.0
 	github.com/charmbracelet/keygen v0.1.2
 	github.com/charmbracelet/lipgloss v0.4.0
-	github.com/charmbracelet/wish v0.1.0
+	github.com/charmbracelet/wish v0.1.1
 	github.com/dgraph-io/badger/v3 v3.2011.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/form3tech-oss/jwt-go v3.2.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/charmbracelet/lipgloss v0.4.0 h1:768h64EFkGUr8V5yAKV7/Ta0NiVceiPaV+Pp
 github.com/charmbracelet/lipgloss v0.4.0/go.mod h1:vmdkHvce7UzX6xkyf4cca8WlwdQ5RQr8fzta+xl7BOM=
 github.com/charmbracelet/wish v0.1.0 h1:t57Fhr1rqxfGNjR0DXcgVvYLA3mmkiCgczWrATrviIY=
 github.com/charmbracelet/wish v0.1.0/go.mod h1:tD+sb5aS1SSX0t7hIZXXUonv2YbnFNCnU6qfOolKKUE=
+github.com/charmbracelet/wish v0.1.1 h1:BLsUBlHzIxw5ebzmBzxUUMfakdteew6gQOhudhsLKpM=
+github.com/charmbracelet/wish v0.1.1/go.mod h1:tD+sb5aS1SSX0t7hIZXXUonv2YbnFNCnU6qfOolKKUE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=


### PR DESCRIPTION
The client was encoding the current local time into the encryption keys and pushing them to the server. This was causing an issue when the time zones weren't matched. This fix lets the server set the `created_at` date for encryption keys.

Fixes #29.