### PR TITLE
Decrease default BadgerDB vlog value size to 10MB

### DIFF
--- a/kv/kv.go
+++ b/kv/kv.go
@@ -56,9 +56,16 @@ func OpenWithDefaults(name string) (*KV, error) {
 	}
 	pn := filepath.Join(fmt.Sprintf("%s/kv/", dd), name)
 	opts := badger.DefaultOptions(pn).WithLoggingLevel(badger.ERROR)
+
 	// By default we have no logger as it will interfere with Bubble Tea
 	// rendering. Use Open with custom options to specify one.
 	opts.Logger = nil
+
+	// We default to a 10MB vlog max size (which BadgerDB turns into 20MB vlog
+	// files). The Badger default results in 2GB vlog files, which is quite
+	// large. This will limit the values to 10MB maximum size. If you need more,
+	// please use Open with custom options.
+	opts = opts.WithValueLogFileSize(10000000)
 	return Open(cc, name, opts)
 }
 


### PR DESCRIPTION
By default, Badger sets the .vlog files size to 2GB. This change will shrink them to 20MB. It puts a limit of 10MB on the value size, but leaves open the option for custom sizing via Badger options.