### PR TITLE
Use the same path if no destination path specified

### DIFF
--- a/cmd/fs.go
+++ b/cmd/fs.go
@@ -253,7 +253,24 @@ func fsCopy(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return lrfs.copy(args[0], args[1], isRecursive)
+
+	src := args[0]
+	dst := args[1]
+	if strings.HasPrefix(src, "charm:") {
+		return lrfs.copy(src, dst, isRecursive)
+	}
+
+	// `charm fs cp foo charm:` will copy foo to charm:/foo
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	if !srcInfo.IsDir() && (dst == "charm:" || dst == "charm:/") {
+		dst = "charm:/" + filepath.Base(src)
+	}
+
+	return lrfs.copy(src, dst, isRecursive)
 }
 
 func fsList(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
The `fs copy` command will use the same path if the source file is a
regular file and no destination path was specified. For example:

`charm fs cp foo charm:` will copy file foo to `charm:/foo`

which is convenient when you don't want to specify a different file name
for the destination file, saving you some typing.

Currently a proposal, happy to add some tests if accepted.