### PR TITLE
Add basic charm serve integration tests

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -46,7 +46,7 @@ var (
 			if err != nil {
 				return err
 			}
-			s.Start()
+			s.Start(cmd.Context())
 			return nil
 		},
 	}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -34,7 +34,7 @@ func TestServe(t *testing.T) {
 }
 
 func waitForServer(addr string) bool {
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		conn, err := net.Dial("tcp", addr)
 		if err == nil {
 			conn.Close()

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServe(t *testing.T) {
+	tempDir := t.TempDir()
+	out := bytes.NewBufferString("")
+	log.SetOutput(out)
+	ServeCmd.SetArgs([]string{"--data-dir", tempDir})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go ServeCmd.ExecuteContext(ctx)
+	defer cancel()
+
+	if !waitForServer(":35354") {
+		assert.FailNow(t, "server did not start")
+	}
+
+	dbDir := filepath.Join(tempDir, "db")
+	assert.Regexp(t, regexp.MustCompile("HTTP server listening on: :35354"), out.String())
+	assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("Opening SQLite db: %s", dbDir)), out.String())
+}
+
+func waitForServer(addr string) bool {
+	for i := 0; i < 10; i++ {
+		conn, err := net.Dial("tcp", addr)
+		if err == nil {
+			conn.Close()
+			return true
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	return false
+}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -65,7 +65,7 @@ func TestServe(t *testing.T) {
 }
 
 func waitForServer(addr string) bool {
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 40; i++ {
 		conn, err := net.Dial("tcp", addr)
 		if err == nil {
 			conn.Close()

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3,34 +3,62 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"log"
 	"net"
+	"os"
 	"path/filepath"
 	"regexp"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
+// Thread safe buffer to avoid data races when setting a custom writer
+// for the log
+type Buffer struct {
+	b bytes.Buffer
+	m sync.Mutex
+}
+
+func (b *Buffer) Read(p []byte) (n int, err error) {
+	b.m.Lock()
+	defer b.m.Unlock()
+	return b.b.Read(p)
+}
+
+func (b *Buffer) Write(p []byte) (n int, err error) {
+	b.m.Lock()
+	defer b.m.Unlock()
+	return b.b.Write(p)
+}
+
+func (b *Buffer) String() string {
+	b.m.Lock()
+	defer b.m.Unlock()
+	return b.b.String()
+}
+
 func TestServe(t *testing.T) {
 	tempDir := t.TempDir()
-	out := bytes.NewBufferString("")
-	log.SetOutput(out)
+	buf := Buffer{}
+	log.SetOutput(&buf)
+	defer func() {
+		log.SetOutput(os.Stderr)
+	}()
 	ServeCmd.SetArgs([]string{"--data-dir", tempDir})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go ServeCmd.ExecuteContext(ctx)
-	defer cancel()
 
 	if !waitForServer(":35354") {
 		assert.FailNow(t, "server did not start")
 	}
+	cancel()
 
-	dbDir := filepath.Join(tempDir, "db")
-	assert.Regexp(t, regexp.MustCompile("HTTP server listening on: :35354"), out.String())
-	assert.Regexp(t, regexp.MustCompile(fmt.Sprintf("Opening SQLite db: %s", dbDir)), out.String())
+	assert.DirExists(t, filepath.Join(tempDir, "db"))
+	assert.Regexp(t, regexp.MustCompile("HTTP server listening on: :35354"), buf.String())
 }
 
 func waitForServer(addr string) bool {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log"
 	"net"
 	"os"
@@ -59,6 +60,8 @@ func TestServe(t *testing.T) {
 
 	assert.DirExists(t, filepath.Join(tempDir, "db"))
 	assert.Regexp(t, regexp.MustCompile("HTTP server listening on: :35354"), buf.String())
+	// helps with debugging if test fails
+	fmt.Println(buf.String())
 }
 
 func waitForServer(addr string) bool {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/muesli/sasquatch v0.0.0-20200811221207-66979d92330a
 	github.com/muesli/toktok v0.0.0-20201007181047-c74187025f3f
 	github.com/spf13/cobra v1.0.0
+	github.com/stretchr/testify v1.7.0
 	goji.io v2.0.2+incompatible
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	modernc.org/sqlite v1.14.2
@@ -49,6 +50,7 @@ require (
 	github.com/jacobsa/ogletest v0.0.0-20170503003838-80d50a735a11 // indirect
 	github.com/jacobsa/reqtrace v0.0.0-20150505043853-245c9e0234cb // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a // indirect
@@ -59,8 +61,6 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/objx v0.1.1 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20200730060457-89a2a8a1fb0b // indirect
 	go.opencensus.io v0.22.5 // indirect
 	golang.org/x/mod v0.3.0 // indirect
@@ -70,6 +70,7 @@ require (
 	golang.org/x/tools v0.0.0-20201124115921-2c860bdd6e78 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 	lukechampine.com/uint128 v1.1.1 // indirect
 	modernc.org/cc/v3 v3.35.18 // indirect

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/atotto/clipboard v0.1.2 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/containerd/console v1.0.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgraph-io/ristretto v0.0.4-0.20210122082011-bb5d392ed82d // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
@@ -54,9 +55,11 @@ require (
 	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
 	github.com/muesli/termenv v0.9.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20200730060457-89a2a8a1fb0b // indirect
 	go.opencensus.io v0.22.5 // indirect
@@ -67,6 +70,7 @@ require (
 	golang.org/x/tools v0.0.0-20201124115921-2c860bdd6e78 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 	lukechampine.com/uint128 v1.1.1 // indirect
 	modernc.org/cc/v3 v3.35.18 // indirect
 	modernc.org/ccgo/v3 v3.12.82 // indirect

--- a/go.sum
+++ b/go.sum
@@ -165,9 +165,11 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
@@ -270,7 +272,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -418,6 +419,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=

--- a/go.sum
+++ b/go.sum
@@ -270,6 +270,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -26,4 +26,5 @@ type DB interface {
 	PostNews(subject string, body string, tags []string) error
 	GetNews(id string) (*charm.News, error)
 	GetNewsList(tag string, page int) ([]*charm.News, error)
+	Close() error
 }

--- a/server/db/sqlite/storage.go
+++ b/server/db/sqlite/storage.go
@@ -596,3 +596,7 @@ func (me *DB) wrapTransaction(f func(tx *sql.Tx) error) error {
 	}
 	return tx.Commit()
 }
+
+func (me *DB) Close() error {
+	return me.db.Close()
+}

--- a/server/http.go
+++ b/server/http.go
@@ -82,7 +82,7 @@ func (s *HTTPServer) Start(ctx context.Context) {
 	}
 
 	healthServer := &http.Server{
-		Addr: fmt.Sprintf(":%s", s.cfg.HealthPort),
+		Addr: fmt.Sprintf(":%d", s.cfg.HealthPort),
 	}
 
 	go func() {

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@
 package server
 
 import (
+	"context"
 	"crypto/tls"
 	"log"
 	"path/filepath"
@@ -97,11 +98,17 @@ func NewServer(cfg *Config) (*Server, error) {
 }
 
 // Start starts the HTTP, SSH and stats HTTP servers for the Charm Cloud.
-func (srv *Server) Start() {
+func (srv *Server) Start(ctx context.Context) {
 	go func() {
-		srv.http.Start()
+		srv.http.Start(ctx)
 	}()
-	srv.ssh.Start()
+	srv.ssh.Start(ctx)
+
+	// close the stats database when we're done
+	err := srv.Config.Stats.Close()
+	if err != nil {
+		log.Printf("could not close stats database: %s", err)
+	}
 }
 
 func (srv *Server) init(cfg *Config) {

--- a/server/ssh.go
+++ b/server/ssh.go
@@ -78,8 +78,7 @@ func (me *SSHServer) Start(ctx context.Context) {
 	}()
 
 	<-ctx.Done()
-	err := me.server.Shutdown(ctx)
-	if err != context.Canceled {
+	if err := me.server.Shutdown(ctx); err != context.Canceled {
 		log.Printf("unexpected error shutting down ssh server: %s", err)
 	}
 

--- a/server/stats/sqlite/sqlite.go
+++ b/server/stats/sqlite/sqlite.go
@@ -145,3 +145,8 @@ func (s *Stats) PostNews() {
 func (s *Stats) GetNewsList() {
 	s.increment("get_news_list")
 }
+
+// Close closes the database freeing up resources.
+func (s *Stats) Close() error {
+	return s.db.Close()
+}

--- a/server/stats/stats.go
+++ b/server/stats/stats.go
@@ -19,4 +19,5 @@ type Stats interface {
 	GetNewsList()
 	GetNews()
 	PostNews()
+	Close() error
 }


### PR DESCRIPTION
Tests for https://github.com/charmbracelet/charm/pull/36 that was merged recently.

Some notes:

Introduced the `testify` dependency. Happy to remove it if you prefer to test without it.

The test waits for the server to start serving requests so we can test the output, database path, etc. I did it testing we can actually establish a connection to the HTTP port which also works as a test, but has the potential of introducing test flakiness, given we wait for a fixed amount of time for the server to start. Unlikely since 5 secs should be plenty for the server to start, but the potential is there.

cc @muesli @toby 