### PR TITLE
Wrap cryptCheck errors

### DIFF
--- a/client/crypt.go
+++ b/client/crypt.go
@@ -19,7 +19,7 @@ func (cc *Client) KeyForID(gid string) (*charm.EncryptKey, error) {
 	if len(cc.plainTextEncryptKeys) == 0 {
 		err := cc.cryptCheck()
 		if err != nil {
-			return nil, fmt.Errorf("failed crypt check")
+			return nil, fmt.Errorf("failed crypt check: %w", err)
 		}
 	}
 	if gid == "" {


### PR DESCRIPTION
`cryptCheck` can return a number of different errors so it's useful to
wrap the error returned.