### PR TITLE
[PoC] Tavern integration

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -22,7 +22,7 @@ func RequestLimitMiddleware() func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var maxRequestSize int64
-			if strings.HasPrefix(r.URL.Path, "/v1/fs") {
+			if strings.HasPrefix(r.URL.Path, "/v1/fs") || strings.HasPrefix(r.URL.Path, "/v1/tavern/") {
 				maxRequestSize = 1 << 30 // limit request size to 1GB for fs endpoints
 			} else {
 				maxRequestSize = 1 << 20 // limit request size to 1MB for other endpoints

--- a/server/server.go
+++ b/server/server.go
@@ -23,6 +23,7 @@ type Config struct {
 	HTTPScheme  string `env:"CHARM_SERVER_HTTP_SCHEME" default:"http"`
 	StatsPort   int    `env:"CHARM_SERVER_STATS_PORT" default:"35355"`
 	HealthPort  string `env:"CHARM_SERVER_HEALTH_PORT" default:"35356"`
+	TavernPort  string `env:"CHARM_SERVER_HEALTH_PORT" default:"35357"`
 	DataDir     string `env:"CHARM_SERVER_DATA_DIR" default:"./data"`
 	TLSKeyFile  string `env:"CHARM_SERVER_TLS_KEY_FILE" default:""`
 	TLSCertFile string `env:"CHARM_SERVER_TLS_CERT_FILE" default:""`
@@ -39,6 +40,7 @@ type Server struct {
 	Config *Config
 	ssh    *SSHServer
 	http   *HTTPServer
+	tavern *TavernServer
 }
 
 // DefaultConfig returns a Config with the values populated with the defaults
@@ -93,6 +95,10 @@ func NewServer(cfg *Config) (*Server, error) {
 		return nil, err
 	}
 	s.http = hs
+
+	ts := NewTavernServer(cfg)
+	s.tavern = ts
+
 	return s, nil
 }
 
@@ -101,6 +107,9 @@ func (srv *Server) Start() {
 	go func() {
 		srv.http.Start()
 	}()
+
+	go srv.tavern.Start()
+
 	srv.ssh.Start()
 }
 

--- a/server/tavern.go
+++ b/server/tavern.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/meowgorithm/babylogger"
+	"goji.io"
+	"goji.io/pat"
+)
+
+// TavernServer is the HTTP server for Charm public file server.
+type TavernServer struct {
+	handler     http.Handler
+	uploadsPath string
+	config      *Config
+}
+
+func NewTavernServer(cfg *Config) *TavernServer {
+	uploadsPath := filepath.Join(".", cfg.DataDir, "tavern")
+
+	mux := goji.NewMux()
+	mux.Use(babylogger.Middleware)
+
+	fs := http.FileServer(http.Dir(uploadsPath))
+	mux.Handle(pat.Get("/*"), fs)
+
+	ts := &TavernServer{config: cfg, uploadsPath: uploadsPath, handler: mux}
+
+	return ts
+}
+
+func (s *TavernServer) Start() error {
+	err := os.MkdirAll(s.uploadsPath, os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	listenAddr := fmt.Sprintf(":%s", s.config.TavernPort)
+	srv := &http.Server{
+		Addr:    listenAddr,
+		Handler: s.handler,
+	}
+
+	log.Printf("Tavern server listening on %s, serving %s", listenAddr, s.uploadsPath)
+	return srv.ListenAndServe()
+}


### PR DESCRIPTION
I took a stab at integrating [Tavern](https://github.com/rubiojr/tavern) server functionality into charm, see how hard would it be. Not much!

Some notes about the implementation, that may or may not make sense to y'all:

* There's a new upload route in the HTTP server that handles multipart uploads (`/v1/tavern/upload`), we get auth for free, request limits, etc that way
* There's a new public HTTP server listening in a different port (`35357`) that servers the uploaded files without auth. Rather than integrating all this into existing HTTP server, I chose that route that provides a bit better isolation plus makes things like TLS termination with reverse proxy servers like Caddy a bit easier, or having dedicated docker container with a charm server that disables every other server except the public file server for example, or simply leaves public file serving to upstream HTTP servers disabling it.
* Tavern is still an experiment, so this inherits all Tavern limitations and issues, except the server-to-server JWT auth that the Tavern server was performing to validate client uploads that is no longer necessary.
* The tavern client can be used (something like ` ./tavern publish --charm-server-host my-charm-server-host --server-url http://my-charm-server-host:35354 hello`), but this could be integrated into a new `charm publish` or `charm fs publish` command as well. 
