### PR TITLE
serve: add --health-port flag

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -9,9 +9,10 @@ import (
 )
 
 var (
-	serverHTTPPort int
-	serverSSHPort  int
-	serverDataDir  string
+	serverHTTPPort   int
+	serverSSHPort    int
+	serverHealthPort int
+	serverDataDir    string
 
 	//ServeCmd is the cobra.Command to self-host the Charm Cloud.
 	ServeCmd = &cobra.Command{
@@ -28,6 +29,9 @@ var (
 			}
 			if serverSSHPort != 0 {
 				cfg.SSHPort = serverSSHPort
+			}
+			if serverHealthPort != 0 {
+				cfg.HealthPort = serverHealthPort
 			}
 			if serverDataDir != "" {
 				cfg.DataDir = serverDataDir
@@ -51,5 +55,6 @@ var (
 func init() {
 	ServeCmd.Flags().IntVar(&serverHTTPPort, "http-port", 0, "HTTP port to listen on")
 	ServeCmd.Flags().IntVar(&serverSSHPort, "ssh-port", 0, "SSH port to listen on")
+	ServeCmd.Flags().IntVar(&serverHealthPort, "health-port", 0, "Health port to listen on")
 	ServeCmd.Flags().StringVar(&serverDataDir, "data-dir", "", "Directory to store SQLite db, SSH keys and file data")
 }

--- a/server/http.go
+++ b/server/http.go
@@ -81,7 +81,7 @@ func (s *HTTPServer) Start() {
 	}
 
 	go func() {
-		err := http.ListenAndServe(fmt.Sprintf(":%s", s.cfg.HealthPort), nil)
+		err := http.ListenAndServe(fmt.Sprintf(":%d", s.cfg.HealthPort), nil)
 		if err != nil {
 			log.Fatalf("http health endpoint server exited with error: %s", err)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -22,7 +22,7 @@ type Config struct {
 	HTTPPort    int    `env:"CHARM_SERVER_HTTP_PORT" default:"35354"`
 	HTTPScheme  string `env:"CHARM_SERVER_HTTP_SCHEME" default:"http"`
 	StatsPort   int    `env:"CHARM_SERVER_STATS_PORT" default:"35355"`
-	HealthPort  string `env:"CHARM_SERVER_HEALTH_PORT" default:"35356"`
+	HealthPort  int    `env:"CHARM_SERVER_HEALTH_PORT" default:"35356"`
 	DataDir     string `env:"CHARM_SERVER_DATA_DIR" default:"./data"`
 	TLSKeyFile  string `env:"CHARM_SERVER_TLS_KEY_FILE" default:""`
 	TLSCertFile string `env:"CHARM_SERVER_TLS_CERT_FILE" default:""`


### PR DESCRIPTION
Fixes health port type also, now being consistent with SSH and HTTP port
types.