### PR TITLE
[WiP] Add flag to disable automatic account creation

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -18,6 +18,7 @@ var (
 	serverSSHPort    int
 	serverHealthPort int
 	serverDataDir    string
+	disableAccounts  bool
 
 	//ServeCmd is the cobra.Command to self-host the Charm Cloud.
 	ServeCmd = &cobra.Command{
@@ -41,6 +42,7 @@ var (
 			if serverDataDir != "" {
 				cfg.DataDir = serverDataDir
 			}
+			cfg.AutoAccounts = !disableAccounts
 			sp := filepath.Join(cfg.DataDir, ".ssh")
 			kp, err := keygen.NewWithWrite(sp, "charm_server", []byte(""), keygen.Ed25519)
 			if err != nil {
@@ -73,4 +75,5 @@ func init() {
 	ServeCmd.Flags().IntVar(&serverSSHPort, "ssh-port", 0, "SSH port to listen on")
 	ServeCmd.Flags().IntVar(&serverHealthPort, "health-port", 0, "Health port to listen on")
 	ServeCmd.Flags().StringVar(&serverDataDir, "data-dir", "", "Directory to store SQLite db, SSH keys and file data")
+	ServeCmd.Flags().BoolVar(&disableAccounts, "disable-accounts", false, "Create accounts for new users automatically if they don't exist")
 }

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -2,6 +2,7 @@ package proto
 
 import (
 	"errors"
+	"fmt"
 )
 
 // ErrMalformedKey parsing error for bad ssh key.
@@ -37,7 +38,7 @@ type ErrAuthFailed struct {
 }
 
 // Error returns the boxed error string.
-func (e ErrAuthFailed) Error() string { return e.Err.Error() }
+func (e ErrAuthFailed) Error() string { return fmt.Sprintf("authentication failed: %s", e.Err.Error()) }
 
 // Unwrap returns the boxed error.
 func (e ErrAuthFailed) Unwrap() error { return e.Err }

--- a/server/auth.go
+++ b/server/auth.go
@@ -51,7 +51,7 @@ func (me *SSHServer) handleAPIAuth(s ssh.Session) {
 		me.errorLog.Println(err)
 		return
 	}
-	u, err := me.db.UserForKey(key, true)
+	u, err := me.db.UserForKey(key, me.config.AutoAccounts)
 	if err != nil {
 		me.errorLog.Println(err)
 		return
@@ -85,7 +85,7 @@ func (me *SSHServer) handleAPIKeys(s ssh.Session) {
 		_ = me.sendAPIMessage(s, "Missing key")
 		return
 	}
-	u, err := me.db.UserForKey(key, true)
+	u, err := me.db.UserForKey(key, me.config.AutoAccounts)
 	if err != nil {
 		me.errorLog.Println(err)
 		_ = me.sendAPIMessage(s, fmt.Sprintf("API keys error: %s", err))
@@ -121,7 +121,7 @@ func (me *SSHServer) handleID(s ssh.Session) {
 		me.errorLog.Println(err)
 		return
 	}
-	u, err := me.db.UserForKey(key, true)
+	u, err := me.db.UserForKey(key, me.config.AutoAccounts)
 	if err != nil {
 		me.errorLog.Println(err)
 		return

--- a/server/link.go
+++ b/server/link.go
@@ -152,7 +152,7 @@ func (me *SSHServer) LinkGen(lt charm.LinkTransport) error {
 			if u.CharmID == "" {
 				// Create account for the link generator public key if it doesn't exist
 				log.Printf("Creating account for token: %s", tok)
-				u, err = me.db.UserForKey(u.PublicKey.Key, true)
+				u, err = me.db.UserForKey(u.PublicKey.Key, me.config.AutoAccounts)
 				if err != nil {
 					log.Printf("Create account error: %s", err)
 					l.Status = charm.LinkStatusError
@@ -272,7 +272,7 @@ func (me *SSHServer) handleLinkGenAPI(s ssh.Session) {
 		_ = me.sendAPIMessage(s, fmt.Sprintf("Missing public key %s", err))
 		return
 	}
-	u, err := me.db.UserForKey(key, true)
+	u, err := me.db.UserForKey(key, me.config.AutoAccounts)
 	if err != nil {
 		_ = me.sendAPIMessage(s, fmt.Sprintf("Storage key lookup error: %s", err))
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -21,23 +21,24 @@ import (
 
 // Config is the configuration for the Charm server.
 type Config struct {
-	Host        string `env:"CHARM_SERVER_HOST"`
-	SSHPort     int    `env:"CHARM_SERVER_SSH_PORT" default:"35353"`
-	HTTPPort    int    `env:"CHARM_SERVER_HTTP_PORT" default:"35354"`
-	StatsPort   int    `env:"CHARM_SERVER_STATS_PORT" default:"35355"`
-	HealthPort  int    `env:"CHARM_SERVER_HEALTH_PORT" default:"35356"`
-	DataDir     string `env:"CHARM_SERVER_DATA_DIR" default:"./data"`
-	TLSKeyFile  string `env:"CHARM_SERVER_TLS_KEY_FILE"`
-	TLSCertFile string `env:"CHARM_SERVER_TLS_CERT_FILE"`
-	errorLog    *log.Logger
-	PublicKey   []byte
-	PrivateKey  []byte
-	DB          db.DB
-	FileStore   storage.FileStore
-	Stats       stats.Stats
-	tlsConfig   *tls.Config
-	jwtKeyPair  JSONWebKeyPair
-	httpScheme  string
+	Host         string `env:"CHARM_SERVER_HOST"`
+	SSHPort      int    `env:"CHARM_SERVER_SSH_PORT" default:"35353"`
+	HTTPPort     int    `env:"CHARM_SERVER_HTTP_PORT" default:"35354"`
+	StatsPort    int    `env:"CHARM_SERVER_STATS_PORT" default:"35355"`
+	HealthPort   int    `env:"CHARM_SERVER_HEALTH_PORT" default:"35356"`
+	DataDir      string `env:"CHARM_SERVER_DATA_DIR" default:"./data"`
+	TLSKeyFile   string `env:"CHARM_SERVER_TLS_KEY_FILE"`
+	TLSCertFile  string `env:"CHARM_SERVER_TLS_CERT_FILE"`
+	errorLog     *log.Logger
+	PublicKey    []byte
+	PrivateKey   []byte
+	DB           db.DB
+	FileStore    storage.FileStore
+	Stats        stats.Stats
+	tlsConfig    *tls.Config
+	jwtKeyPair   JSONWebKeyPair
+	httpScheme   string
+	AutoAccounts bool
 }
 
 // Server contains the SSH and HTTP servers required to host the Charm Cloud.

--- a/server/server.go
+++ b/server/server.go
@@ -38,7 +38,7 @@ type Config struct {
 	tlsConfig    *tls.Config
 	jwtKeyPair   JSONWebKeyPair
 	httpScheme   string
-	AutoAccounts bool
+	AutoAccounts bool `env:"CHARM_SERVER_AUTO_ACCOUNTS" default:"true"`
 }
 
 // Server contains the SSH and HTTP servers required to host the Charm Cloud.


### PR DESCRIPTION
Charm currently creates server side accounts automatically for new users when their public key isn't found in the database.
This PR adds a new `--disable-accounts` flag to `serve` to disable automatic account creation server side when the user (public key) isn't found, which is usually desired if you want your Charm server to be limited to the accounts you manually create.

The PR doesn't change the current behaviour, automatic account creation is still active by default.

![Screenshot from 2021-12-31 11-55-43](https://user-images.githubusercontent.com/10998/147819692-396a864a-c612-4288-a143-23607637722a.png)

I'm not particularly married to the `--disable-accounts` flag name, but didn't want to make it unusually longer like `--disable-account-creation`. Suggestions more than welcome.

cc @toby [Slack context](https://charmbracelet.slack.com/archives/CQ2E9CGTV/p1640714424292100)

## Missing

* [ ] Unit & integration tests
* [ ] Should we add a new `accounts` command to create user accounts on the server when account auto creation has been disabled? should that happen here or in a new dedicated PR?
* [ ] The underlying error cause (like `unexpected end of JSON input`) tends to be cryptic and not very useful for the end user, should we hide it behind a `--debug` flag?