### PR TITLE
Don't print CLI errors twice

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,6 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Cobra already prints the errors to stderr when using `RunE` to execute
the commands, so adding an extra `fmt.Println` here duplicates errors.

Without the patch:
![Screenshot from 2021-12-31 12-27-04](https://user-images.githubusercontent.com/10998/147820922-dbea94f7-6db6-40be-8db1-72aba2e14587.png)


With the patch:
![Screenshot from 2021-12-31 12-26-12](https://user-images.githubusercontent.com/10998/147820889-0b72b77b-221f-4add-877a-ad03559b5d47.png)

