### PR TITLE
Expose client http scheme as an env variable

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -13,6 +13,7 @@ func (cc *Client) Auth() (*charm.Auth, error) {
 	cc.authLock.Lock()
 	defer cc.authLock.Unlock()
 
+	cfg := cc.Config
 	if cc.claims == nil || cc.claims.Valid() != nil {
 		auth := &charm.Auth{}
 		s, err := cc.sshSession()
@@ -29,7 +30,10 @@ func (cc *Client) Auth() (*charm.Auth, error) {
 		if err != nil {
 			return nil, charm.ErrAuthFailed{Err: err}
 		}
-		cc.httpScheme = auth.HTTPScheme
+		// Set HTTP scheme from the server if it's not set.
+		if cfg.HTTPScheme == "" {
+			cfg.HTTPScheme = auth.HTTPScheme
+		}
 		p := &jwt.Parser{}
 		token, _, err := p.ParseUnverified(auth.JWT, &jwt.StandardClaims{})
 		if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -24,11 +24,12 @@ var nameValidator = regexp.MustCompile("^[a-zA-Z0-9]{1,50}$")
 
 // Config contains the Charm client configuration.
 type Config struct {
-	Host     string `env:"CHARM_HOST" default:"cloud.charm.sh"`
-	SSHPort  int    `env:"CHARM_SSH_PORT" default:"35353"`
-	HTTPPort int    `env:"CHARM_HTTP_PORT" default:"35354"`
-	Debug    bool   `env:"CHARM_DEBUG" default:"false"`
-	Logfile  string `env:"CHARM_LOGFILE" default:""`
+	Host       string `env:"CHARM_HOST" default:"cloud.charm.sh"`
+	SSHPort    int    `env:"CHARM_SSH_PORT" default:"35353"`
+	HTTPPort   int    `env:"CHARM_HTTP_PORT" default:"35354"`
+	HTTPScheme string `env:"CHARM_HTTP_SCHEME"`
+	Debug      bool   `env:"CHARM_DEBUG" default:"false"`
+	Logfile    string `env:"CHARM_LOGFILE" default:""`
 }
 
 // Client is the Charm client.
@@ -38,7 +39,6 @@ type Client struct {
 	claims               *jwt.StandardClaims
 	authLock             *sync.Mutex
 	sshConfig            *ssh.ClientConfig
-	httpScheme           string
 	plainTextEncryptKeys []*charm.EncryptKey
 	authKeyPaths         []string
 	encryptKeyLock       *sync.Mutex

--- a/client/http.go
+++ b/client/http.go
@@ -56,7 +56,7 @@ func (cc *Client) AuthedRequest(method string, path string, headers http.Header,
 		return nil, err
 	}
 	jwt := auth.JWT
-	req, err := http.NewRequest(method, fmt.Sprintf("%s://%s:%d%s", cc.httpScheme, cfg.Host, cfg.HTTPPort, path), reqBody)
+	req, err := http.NewRequest(method, fmt.Sprintf("%s://%s:%d%s", cfg.HTTPScheme, cfg.Host, cfg.HTTPPort, path), reqBody)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add the ability to set the client HTTP scheme and default to the server's scheme when the environment variable is not provided.

Fixes: https://github.com/charmbracelet/charm/issues/37