### PR TITLE
fix: use PR HEAD ref instead of merge commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,13 @@ jobs:
           go-version: "~1.17"
 
       - name: Checkout code
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout code
+        if: github.event_name == 'push'
         uses: actions/checkout@v2
 
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
actions/checkout@v2 adds a merge commit when cloning a PR. this
pushes the wrong devel docker image tag name since it uses the merge
commit sha instead of the actual PR head.

https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit