### PR TITLE
fix: fs rm with charm: prefix

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -102,7 +102,6 @@ func (cfs *FS) Open(name string) (fs.File, error) {
 	f := &File{
 		info: &FileInfo{},
 	}
-	name = strings.TrimPrefix(name, "charm:")
 	ep, err := cfs.EncryptPath(name)
 	if err != nil {
 		return nil, pathError(name, err)
@@ -235,7 +234,6 @@ func (cfs *FS) WriteFile(name string, src fs.File) error {
 
 // Remove deletes a file from the Charm Cloud server.
 func (cfs *FS) Remove(name string) error {
-	name = strings.TrimPrefix(name, "charm:")
 	ep, err := cfs.EncryptPath(name)
 	if err != nil {
 		return err
@@ -358,6 +356,7 @@ func (fi *FileInfo) Info() (fs.FileInfo, error) {
 
 func (cfs *FS) EncryptPath(path string) (string, error) {
 	eps := make([]string, 0)
+	path = strings.TrimPrefix(path, "charm:")
 	ps := strings.Split(path, "/")
 	for _, p := range ps {
 		ep, err := cfs.crypt.EncryptLookupField(p)

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -235,6 +235,7 @@ func (cfs *FS) WriteFile(name string, src fs.File) error {
 
 // Remove deletes a file from the Charm Cloud server.
 func (cfs *FS) Remove(name string) error {
+	name = strings.TrimPrefix(name, "charm:")
 	ep, err := cfs.EncryptPath(name)
 	if err != nil {
 		return err


### PR DESCRIPTION
fix `charm fs rm` when the path has the `charm:` prefix