### PR TITLE
Graceful shutdown, recover from SSH panics, and use error logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/charmbracelet/lipgloss v0.4.0
 	github.com/charmbracelet/wish v0.1.1
 	github.com/dgraph-io/badger/v3 v3.2011.1
-	github.com/form3tech-oss/jwt-go v3.2.2+incompatible
 	github.com/gliderlabs/ssh v0.3.3
 	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,6 @@ github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
-github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
-github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=

--- a/server/auth.go
+++ b/server/auth.go
@@ -62,7 +62,7 @@ func (me *SSHServer) handleAPIAuth(s ssh.Session) {
 	_ = me.sendJSON(s, charm.Auth{
 		JWT:         j,
 		ID:          u.CharmID,
-		HTTPScheme:  me.config.HTTPScheme,
+		HTTPScheme:  me.config.httpScheme,
 		PublicKey:   u.PublicKey.Key,
 		EncryptKeys: eks,
 	})

--- a/server/http.go
+++ b/server/http.go
@@ -56,6 +56,7 @@ func NewHTTPServer(cfg *Config) (*HTTPServer, error) {
 		Addr:      fmt.Sprintf("%s:%d", cfg.Host, cfg.HealthPort),
 		Handler:   healthMux,
 		TLSConfig: cfg.tlsConfig,
+		ErrorLog:  cfg.errorLog,
 	}
 	mux := goji.NewMux()
 	s := &HTTPServer{
@@ -103,6 +104,7 @@ func (s *HTTPServer) Start() {
 		Addr:      listenAddr,
 		Handler:   s.handler,
 		TLSConfig: s.cfg.tlsConfig,
+		ErrorLog:  s.cfg.errorLog,
 	}
 
 	go func() {

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -17,6 +17,7 @@ type contextKey string
 
 var ctxUserKey contextKey = "charmUser"
 
+// RequestLimitMiddleware limits the request body size to the specified limit.
 func RequestLimitMiddleware() func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@
 package server
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/tls"
 	"fmt"
@@ -121,12 +122,20 @@ func NewServer(cfg *Config) (*Server, error) {
 	return s, nil
 }
 
-// Start starts the HTTP, SSH and stats HTTP servers for the Charm Cloud.
+// Start starts the HTTP, SSH and health HTTP servers for the Charm Cloud.
 func (srv *Server) Start() {
 	go func() {
 		srv.http.Start()
 	}()
 	srv.ssh.Start()
+}
+
+// Shutdown shuts down the HTTP, and SSH and health HTTP servers for the Charm Cloud.
+func (srv *Server) Shutdown(ctx context.Context) error {
+	if err := srv.ssh.Shutdown(ctx); err != nil {
+		return err
+	}
+	return srv.http.Shutdown(ctx)
 }
 
 func (srv *Server) init(cfg *Config) {

--- a/server/server.go
+++ b/server/server.go
@@ -29,6 +29,7 @@ type Config struct {
 	DataDir     string `env:"CHARM_SERVER_DATA_DIR" default:"./data"`
 	TLSKeyFile  string `env:"CHARM_SERVER_TLS_KEY_FILE"`
 	TLSCertFile string `env:"CHARM_SERVER_TLS_CERT_FILE"`
+	errorLog    *log.Logger
 	PublicKey   []byte
 	PrivateKey  []byte
 	DB          db.DB
@@ -86,6 +87,12 @@ func (cfg *Config) WithKeys(publicKey []byte, privateKey []byte) *Config {
 // WithTLSConfig returns a Config with the provided TLS configuration.
 func (cfg *Config) WithTLSConfig(c *tls.Config) *Config {
 	cfg.tlsConfig = c
+	return cfg
+}
+
+// WithErrorLog returns a Config with the provided error log for the server.
+func (cfg *Config) WithErrorLog(l *log.Logger) *Config {
+	cfg.errorLog = l
 	return cfg
 }
 

--- a/server/ssh.go
+++ b/server/ssh.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -64,6 +65,12 @@ func NewSSHServer(cfg *Config) (*SSHServer, error) {
 func (me *SSHServer) Start() {
 	log.Printf("Starting SSH server on %s", me.server.Addr)
 	log.Fatal(me.server.ListenAndServe())
+}
+
+// Shutdown gracefully shuts down the SSH server.
+func (me *SSHServer) Shutdown(ctx context.Context) error {
+	log.Printf("Stopping SSH server on %s", me.server.Addr)
+	return me.server.Shutdown(ctx)
 }
 
 func (me *SSHServer) sendAPIMessage(s ssh.Session, msg string) error {

--- a/server/ssh.go
+++ b/server/ssh.go
@@ -33,11 +33,18 @@ type SSHServer struct {
 	tokenBucket  *toktok.Bucket
 	linkRequests map[charm.Token]chan *charm.Link
 	server       *ssh.Server
+	errorLog     *log.Logger
 }
 
 // NewSSHServer creates a new SSHServer from the provided Config.
 func NewSSHServer(cfg *Config) (*SSHServer, error) {
-	s := &SSHServer{config: cfg}
+	s := &SSHServer{
+		config:   cfg,
+		errorLog: cfg.errorLog,
+	}
+	if s.errorLog == nil {
+		s.errorLog = log.Default()
+	}
 	addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.SSHPort)
 	b, err := toktok.NewBucket(6)
 	if err != nil {

--- a/server/ssh.go
+++ b/server/ssh.go
@@ -37,7 +37,7 @@ type SSHServer struct {
 // NewSSHServer creates a new SSHServer from the provided Config.
 func NewSSHServer(cfg *Config) (*SSHServer, error) {
 	s := &SSHServer{config: cfg}
-	addr := fmt.Sprintf(":%d", cfg.SSHPort)
+	addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.SSHPort)
 	b, err := toktok.NewBucket(6)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* HTTP scheme is now determined by whether or not a tls config or files are provided.
* Implement server graceful shutdown, credit to @caarlos0 
* Recover from SSH panics
* Log server errors to an error logger