### PR TITLE
Use Ed25519 keys for Charm client

### DIFF
--- a/client/crypt.go
+++ b/client/crypt.go
@@ -42,7 +42,7 @@ func (cc *Client) DefaultEncryptKey() (*charm.EncryptKey, error) {
 }
 
 func (cc *Client) findIdentities() ([]sasquatch.Identity, error) {
-	keys, err := FindAuthKeys(cc.Config.Host)
+	keys, err := FindAuthKeys(cc.Config.Host, cc.Config.KeyType)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,8 @@ func (cc *Client) findIdentities() ([]sasquatch.Identity, error) {
 	return ids, nil
 }
 
-func (cc *Client) encryptKeys() ([]*charm.EncryptKey, error) {
+// EncryptKeys returns all of the symmetric encrypt keys for the authed user.
+func (cc *Client) EncryptKeys() ([]*charm.EncryptKey, error) {
 	err := cc.cryptCheck()
 	if err != nil {
 		return nil, err

--- a/client/link.go
+++ b/client/link.go
@@ -126,7 +126,7 @@ func (cc *Client) Link(lh charm.LinkHandler, code string) error {
 // public key with all other linked public keys.
 func (cc *Client) SyncEncryptKeys() error {
 	cc.InvalidateAuth()
-	eks, err := cc.encryptKeys()
+	eks, err := cc.EncryptKeys()
 	if err != nil {
 		return err
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -65,7 +65,7 @@ func initCharmClient(kg keygenSetting) *client.Client {
 					printFormatted(keygenError + err.Error())
 					os.Exit(1)
 				}
-				_, err = keygen.NewWithWrite(dp, "charm", []byte(""), keygen.RSA)
+				_, err = keygen.NewWithWrite(dp, "charm", []byte(""), cfg.KeygenType())
 				if err != nil {
 					printFormatted(keygenError + err.Error())
 					os.Exit(1)

--- a/cmd/migrate_account.go
+++ b/cmd/migrate_account.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/charmbracelet/charm/client"
+	"github.com/charmbracelet/charm/proto"
+	"github.com/spf13/cobra"
+)
+
+// MigrateAccountCmd is a command to convert your legacy RSA SSH keys to the
+// new Ed25519 standard keys
+var MigrateAccountCmd = &cobra.Command{
+	Use:    "migrate-account",
+	Hidden: true,
+	Short:  "",
+	Long:   "",
+	Args:   cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rcfg, err := client.ConfigFromEnv()
+		if err != nil {
+			return err
+		}
+		rcfg.KeyType = "rsa"
+		rsaClient, err := client.NewClient(rcfg)
+		if err != nil {
+			return err
+		}
+
+		ecfg, err := client.ConfigFromEnv()
+		if err != nil {
+			return err
+		}
+		ecfg.KeyType = "ed25519"
+		ed25519Client, err := client.NewClient(ecfg)
+		if err != nil {
+			return err
+		}
+		lh := &linkHandler{linkChan: make(chan string)}
+		go func() {
+			rsaClient.LinkGen(lh)
+		}()
+		tok := <-lh.linkChan
+		ed25519Client.Link(lh, tok)
+		err = rsaClient.SyncEncryptKeys()
+		if err != nil {
+			return err
+		}
+		err = ed25519Client.SyncEncryptKeys()
+		if err != nil {
+		}
+		return nil
+	},
+}
+
+type linkHandler struct {
+	linkChan chan string
+}
+
+func (lh *linkHandler) TokenCreated(l *proto.Link) {
+	// log.Printf("token created %v", l)
+	lh.linkChan <- string(l.Token)
+}
+
+func (lh *linkHandler) TokenSent(l *proto.Link) {
+	// log.Printf("token sent %v", l)
+}
+
+func (lh *linkHandler) ValidToken(l *proto.Link) {
+	// log.Printf("valid token %v", l)
+}
+
+func (lh *linkHandler) InvalidToken(l *proto.Link) {
+	// log.Printf("invalid token %v", l)
+}
+
+func (lh *linkHandler) Request(l *proto.Link) bool {
+	// log.Printf("request %v", l)
+	return true
+}
+
+func (lh *linkHandler) RequestDenied(l *proto.Link) {
+	// log.Printf("request denied %v", l)
+}
+
+func (lh *linkHandler) SameUser(l *proto.Link) {
+	log.Println("Success! Looks like you've done this already.")
+}
+
+func (lh *linkHandler) Success(l *proto.Link) {
+	log.Println("Success! You're good to go.")
+}
+
+func (lh *linkHandler) Timeout(l *proto.Link) {
+	log.Println("Timeout")
+}
+
+func (lh linkHandler) Error(l *proto.Link) {
+	log.Printf("Error %v", l)
+}

--- a/cmd/post_news.go
+++ b/cmd/post_news.go
@@ -26,7 +26,7 @@ var (
 				cfg.DataDir = serverDataDir
 			}
 			sp := filepath.Join(cfg.DataDir, ".ssh")
-			kp, err := keygen.NewWithWrite(sp, "charm_server", []byte(""), keygen.RSA)
+			kp, err := keygen.NewWithWrite(sp, "charm_server", []byte(""), keygen.Ed25519)
 			if err != nil {
 				return err
 			}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -89,11 +89,10 @@ func NewFS() (*FS, error) {
 
 // NewFSWithClient returns an FS with a custom *client.Client.
 func NewFSWithClient(cc *client.Client) (*FS, error) {
-	k, err := cc.DefaultEncryptKey()
+	crypt, err := crypt.NewCrypt()
 	if err != nil {
 		return nil, err
 	}
-	crypt := crypt.NewCryptWithKey(k)
 	return &FS{cc: cc, crypt: crypt, maxFileSize: 1 << 30}, nil
 }
 

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -243,15 +243,3 @@ func (kv *KV) Reset() error {
 	kv.DB = db
 	return kv.Sync()
 }
-
-func openDB(cc *client.Client, name string, opt badger.Options) (*badger.DB, error) {
-	ek, err := encryptKeyFromCharmClient(cc)
-	if err != nil {
-		return nil, err
-	}
-	opt, err = OptionsWithEncryption(opt, ek, 32768)
-	if err != nil {
-		return nil, err
-	}
-	return badger.OpenManaged(opt)
-}

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func init() {
 		cmd.KVCmd,
 		cmd.FSCmd,
 		cmd.CryptCmd,
+		cmd.MigrateAccountCmd,
 	)
 }
 

--- a/ui/keygen/keygen.go
+++ b/ui/keygen/keygen.go
@@ -147,7 +147,7 @@ func GenerateKeys(host string) tea.Cmd {
 		if err != nil {
 			return FailedMsg{err}
 		}
-		_, err = keygen.NewWithWrite(dp, "charm", nil, keygen.RSA)
+		_, err = keygen.NewWithWrite(dp, "charm", nil, keygen.Ed25519)
 		if err != nil {
 			return FailedMsg{err}
 		}


### PR DESCRIPTION
* Move from RSA to Ed25519 for default SSH keys for Charm accounts
* Added `charm migrate-account` command to upgarade legacy accounts
* Allow for configurable key type though env vars and Config
* Move from using a default encryption key to trying all encryption keys