### PR TITLE
fix: kv ignore openDB error

### DIFF
--- a/kv/client.go
+++ b/kv/client.go
@@ -177,6 +177,9 @@ func openDB(cc *client.Client, name string, opt badger.Options) (*badger.DB, err
 			if err == nil {
 				break
 			}
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	if db == nil {


### PR DESCRIPTION
`openDB` doesn't check for badger db open errors

Fixes: https://github.com/charmbracelet/skate/issues/27