### PR TITLE
fix: ui/keygen not generating keys for host

### DIFF
--- a/ui/keygen/keygen.go
+++ b/ui/keygen/keygen.go
@@ -29,6 +29,7 @@ const (
 // NewProgram creates a new keygen TUI program
 func NewProgram(host string, fancy bool) *tea.Program {
 	m := NewModel()
+	m.host = host
 	m.standalone = true
 	m.fancy = fancy
 	m.spinner = spinner.NewModel()


### PR DESCRIPTION
ui/keygen ignores the passed host

Fixes: https://github.com/charmbracelet/charm/issues/93