### PR TITLE
Speed up client FS, support server user max storage capacity, use authorized_keys, and some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,25 @@ of serving an entire Charm instance:
 charm serve
 ```
 
-To change hosts users can set `CHARM_HOST` to the domain or IP or their
+### Server settings
+
+The Charm server can be configured using environment variables. These are the defaults:
+
+* `CHARM_SERVER_BIND_ADDRESS`: Network interface to listen to (_default 0.0.0.0_)
+* `CHARM_SERVER_HOST`: Hostname to advertise (_default localhost_)
+* `CHARM_SERVER_SSH_PORT`: SSH server port to listen to (_default 35353_)
+* `CHARM_SERVER_HTTP_PORT`: HTTP server port to listen to (_default 35354_)
+* `CHARM_SERVER_STATS_PORT`: Stats server port to listen to (_default 35355_)
+* `CHARM_SERVER_HEALTH_PORT`: Health server port to listen to (_default 35356_)
+* `CHARM_SERVER_DATA_DIR`: Server data directory (_default ./data_)
+* `CHARM_SERVER_USE_TLS`: Whether to use TLS (_default false_)
+* `CHARM_SERVER_TLS_KEY_FILE`: The TLS key file path to use
+* `CHARM_SERVER_TLS_CERT_FILE`: The TLS cert file path to use
+* `CHARM_SERVER_PUBLIC_URL`: Server public URL, useful when hosting the Charm server behind a TLS enabled reverse proxy
+* `CHARM_SERVER_ENABLE_METRICS`: Whether to enable collecting Prometheus metrics (_default false_) Metrics can be accessed from `http://<CHARM_SERVER_HOST>:<CHARM_SERVER_STATS_PORT>/metrics`
+* `CHARM_SERVER_USER_MAX_STORAGE`: Maximum FS storage for a user (_default 0_) Zero means no limit
+
+To change hosts, users can set `CHARM_HOST` to the domain or IP of their
 choosing:
 
 ```bash

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -2,6 +2,7 @@ package proto
 
 import (
 	"errors"
+	"fmt"
 )
 
 // ErrMalformedKey parsing error for bad ssh key.
@@ -40,7 +41,7 @@ type ErrAuthFailed struct {
 }
 
 // Error returns the boxed error string.
-func (e ErrAuthFailed) Error() string { return e.Err.Error() }
+func (e ErrAuthFailed) Error() string { return fmt.Sprintf("authentication failed: %s", e.Err) }
 
 // Unwrap returns the boxed error.
 func (e ErrAuthFailed) Unwrap() error { return e.Err }

--- a/server/http.go
+++ b/server/http.go
@@ -143,8 +143,8 @@ func (s *HTTPServer) renderError(w http.ResponseWriter) {
 }
 
 func (s *HTTPServer) renderCustomError(w http.ResponseWriter, msg string, status int) {
-	w.WriteHeader(status)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(charm.Message{Message: msg})
 }
 
@@ -346,6 +346,7 @@ func (s *HTTPServer) handleDeleteFile(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *HTTPServer) handleGetNewsList(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
 	p := r.FormValue("page")
 	if p == "" {
 		p = "1"
@@ -368,12 +369,12 @@ func (s *HTTPServer) handleGetNewsList(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(ns)
 	s.cfg.Stats.GetNews()
 }
 
 func (s *HTTPServer) handleGetNews(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
 	id := pat.Param(r, "id")
 	news, err := s.db.GetNews(id)
 	if err != nil {
@@ -381,7 +382,6 @@ func (s *HTTPServer) handleGetNews(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(news)
 	s.cfg.Stats.GetNews()
 }

--- a/server/server.go
+++ b/server/server.go
@@ -24,28 +24,29 @@ import (
 
 // Config is the configuration for the Charm server.
 type Config struct {
-	BindAddr      string `env:"CHARM_SERVER_BIND_ADDRESS" envDefault:""`
-	Host          string `env:"CHARM_SERVER_HOST" envDefault:"localhost"`
-	SSHPort       int    `env:"CHARM_SERVER_SSH_PORT" envDefault:"35353"`
-	HTTPPort      int    `env:"CHARM_SERVER_HTTP_PORT" envDefault:"35354"`
-	StatsPort     int    `env:"CHARM_SERVER_STATS_PORT" envDefault:"35355"`
-	HealthPort    int    `env:"CHARM_SERVER_HEALTH_PORT" envDefault:"35356"`
-	DataDir       string `env:"CHARM_SERVER_DATA_DIR" envDefault:"data"`
-	UseTLS        bool   `env:"CHARM_SERVER_USE_TLS" envDefault:"false"`
-	TLSKeyFile    string `env:"CHARM_SERVER_TLS_KEY_FILE"`
-	TLSCertFile   string `env:"CHARM_SERVER_TLS_CERT_FILE"`
-	PublicURL     string `env:"CHARM_SERVER_PUBLIC_URL"`
-	EnableMetrics bool   `env:"CHARM_SERVER_ENABLE_METRICS" envDefault:"false"`
-	errorLog      *log.Logger
-	PublicKey     []byte
-	PrivateKey    []byte
-	DB            db.DB
-	FileStore     storage.FileStore
-	Stats         stats.Stats
-	linkQueue     charm.LinkQueue
-	tlsConfig     *tls.Config
-	jwtKeyPair    JSONWebKeyPair
-	httpScheme    string
+	BindAddr       string `env:"CHARM_SERVER_BIND_ADDRESS" envDefault:""`
+	Host           string `env:"CHARM_SERVER_HOST" envDefault:"localhost"`
+	SSHPort        int    `env:"CHARM_SERVER_SSH_PORT" envDefault:"35353"`
+	HTTPPort       int    `env:"CHARM_SERVER_HTTP_PORT" envDefault:"35354"`
+	StatsPort      int    `env:"CHARM_SERVER_STATS_PORT" envDefault:"35355"`
+	HealthPort     int    `env:"CHARM_SERVER_HEALTH_PORT" envDefault:"35356"`
+	DataDir        string `env:"CHARM_SERVER_DATA_DIR" envDefault:"data"`
+	UseTLS         bool   `env:"CHARM_SERVER_USE_TLS" envDefault:"false"`
+	TLSKeyFile     string `env:"CHARM_SERVER_TLS_KEY_FILE"`
+	TLSCertFile    string `env:"CHARM_SERVER_TLS_CERT_FILE"`
+	PublicURL      string `env:"CHARM_SERVER_PUBLIC_URL"`
+	EnableMetrics  bool   `env:"CHARM_SERVER_ENABLE_METRICS" envDefault:"false"`
+	UserMaxStorage int64  `env:"CHARM_SERVER_USER_MAX_STORAGE" envDefault:"0"`
+	errorLog       *log.Logger
+	PublicKey      []byte
+	PrivateKey     []byte
+	DB             db.DB
+	FileStore      storage.FileStore
+	Stats          stats.Stats
+	linkQueue      charm.LinkQueue
+	tlsConfig      *tls.Config
+	jwtKeyPair     JSONWebKeyPair
+	httpScheme     string
 }
 
 // Server contains the SSH and HTTP servers required to host the Charm Cloud.

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -9,6 +9,7 @@ import (
 // FileStore is the interface storage backends need to implement to act as a
 // the datastore for the Charm Cloud server.
 type FileStore interface {
+	Stat(charmID string, path string) (fs.FileInfo, error)
 	Get(charmID string, path string) (fs.File, error)
 	Put(charmID string, path string, r io.Reader, mode fs.FileMode) error
 	Delete(charmID string, path string) error


### PR DESCRIPTION
* Use bufferless FS write requests (the encryption part still uses buffers to encrypt files but the request does not)
* Support setting server user max storage capacity via `CHARM_SERVER_USER_MAX_STORAGE`, zero is the default which means storage cap is disabled
* Read `data/.ssh/authorized_keys` if it exists to limit user access to the server