### PR TITLE
fix: fix help msg

### DIFF
--- a/cmd/backup_keys.go
+++ b/cmd/backup_keys.go
@@ -20,7 +20,7 @@ var BackupKeysCmd = &cobra.Command{
 	Use:                   "backup-keys",
 	Hidden:                false,
 	Short:                 "Backup your Charm account keys",
-	Long:                  paragraph(fmt.Sprintf("%s your Charm account keys.", keyword("Backup"))),
+	Long:                  paragraph(fmt.Sprintf("%s your Charm account keys to a tar archive file. \nYou can restore your keys from backup using import-keys. \nRun `charm import-keys -help` to learn more.", keyword("Backup"))),
 	Args:                  cobra.NoArgs,
 	DisableFlagsInUseLine: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/import_keys.go
+++ b/cmd/import_keys.go
@@ -35,7 +35,7 @@ var (
 		Use:                   "import-keys BACKUP.tar",
 		Hidden:                false,
 		Short:                 "Import previously backed up Charm account keys.",
-		Long:                  paragraph(fmt.Sprintf("%s previously backed up Charm account keys.", keyword("Backup"))),
+		Long:                  paragraph(fmt.Sprintf("%s previously backed up Charm account keys.", keyword("Import"))),
 		Args:                  cobra.ExactArgs(1),
 		DisableFlagsInUseLine: false,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Changes:
- [x] Fix typo in `charm import-keys -h`: Backup -> Import
- [x] Enhance help menu for `charm backup-keys` -> did not give much context in previous version

### Related Issues:
#115 