### PR TITLE
Fixed: error strings should not be capitalized

### DIFF
--- a/client/crypt.go
+++ b/client/crypt.go
@@ -24,7 +24,7 @@ func (cc *Client) KeyForID(gid string) (*charm.EncryptKey, error) {
 	}
 	if gid == "" {
 		if len(cc.plainTextEncryptKeys) == 0 {
-			return nil, fmt.Errorf("No keys stored")
+			return nil, fmt.Errorf("no keys stored")
 		}
 		return cc.plainTextEncryptKeys[0], nil
 	}
@@ -33,7 +33,7 @@ func (cc *Client) KeyForID(gid string) (*charm.EncryptKey, error) {
 			return k, nil
 		}
 	}
-	return nil, fmt.Errorf("Key not found for id %s", gid)
+	return nil, fmt.Errorf("key not found for id %s", gid)
 }
 
 // DefaultEncryptKey returns the default EncryptKey for an authed user.

--- a/kv/client.go
+++ b/kv/client.go
@@ -52,7 +52,7 @@ func (f *kvFileInfo) Sys() interface{} {
 
 func (f *kvFile) Stat() (fs.FileInfo, error) {
 	if f.info == nil {
-		return nil, fmt.Errorf("File info not set")
+		return nil, fmt.Errorf("file info not set")
 	}
 	return f.info, nil
 }
@@ -154,7 +154,7 @@ func (kv *KV) syncFrom(mv uint64) error {
 func encryptKeyToBadgerKey(k *charm.EncryptKey) ([]byte, error) {
 	ek := []byte(k.Key)
 	if len(ek) < 32 {
-		return nil, fmt.Errorf("Encryption key is too short")
+		return nil, fmt.Errorf("encryption key is too short")
 	}
 	return ek[0:32], nil
 }

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -73,7 +73,7 @@ func OpenWithDefaults(name string) (*KV, error) {
 // settings enabled for a given encryption key.
 func OptionsWithEncryption(opt badger.Options, encKey []byte, cacheSize int64) (badger.Options, error) {
 	if cacheSize <= 0 {
-		return opt, fmt.Errorf("You must set an index cache size to use encrypted workloads in Badger v3")
+		return opt, fmt.Errorf("you must set an index cache size to use encrypted workloads in Badger v3")
 	}
 	return opt.WithEncryptionKey(encKey).WithIndexCacheSize(cacheSize), nil
 }

--- a/server/db/sqlite/storage.go
+++ b/server/db/sqlite/storage.go
@@ -182,7 +182,7 @@ func (me *DB) AddEncryptKeyForPublicKey(u *charm.User, pk string, gid string, ek
 			return err
 		}
 		if u2.ID != u.ID {
-			return fmt.Errorf("Trying to add encrypted key for unauthorized user")
+			return fmt.Errorf("trying to add encrypted key for unauthorized user")
 		}
 
 		r := me.selectEncryptKey(tx, u2.PublicKey.ID, gid)

--- a/server/link.go
+++ b/server/link.go
@@ -222,7 +222,7 @@ func (me *SSHServer) LinkRequest(lt charm.LinkTransport, key string, token strin
 	if err != nil || !me.linkQueue.ValidateLinkRequest(l.Token) {
 		l.Status = charm.LinkStatusInvalidTokenRequest
 		lt.RequestInvalidToken(l)
-		return fmt.Errorf("Invalid token '%s'", token)
+		return fmt.Errorf("invalid token '%s'", token)
 	}
 	l.Status = charm.LinkStatusValidTokenRequest
 	lt.RequestValidToken(l)
@@ -384,7 +384,7 @@ func (s *channelLinkQueue) ValidateLinkRequest(t charm.Token) bool {
 func (s *channelLinkQueue) WaitLinkRequest(t charm.Token) (chan *charm.Link, error) {
 	lr, ok := s.linkRequests[t]
 	if !ok {
-		return nil, fmt.Errorf("No link request for token: %s", t)
+		return nil, fmt.Errorf("no link request for token: %s", t)
 	}
 	return lr, nil
 }


### PR DESCRIPTION
Just making go-staticcheck happy, fixed capitalized error strings: https://staticcheck.io/docs/checks#ST1005