### PR TITLE
Fixed: checking nil against a never-nil value

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -256,7 +256,7 @@ func (cc *Client) Bio() (*charm.User, error) {
 	if err != nil {
 		return nil, err
 	}
-	if u == nil {
+	if (*u == charm.User{}) {
 		return nil, errors.New("no user data received")
 	}
 	return u, nil


### PR DESCRIPTION
Here, `u` getting checked against a nil: 
https://github.com/charmbracelet/charm/blob/b7d991650ccde9b7d0e466c2aa2966b724217e23/client/client.go#L259

But `u` will be never nil, because here, it gets initalized as a pointer to a default initialized `charm.User` struct:
https://github.com/charmbracelet/charm/blob/b7d991650ccde9b7d0e466c2aa2966b724217e23/client/client.go#L250

I fixed it by comparing `u` value against an empty `charm.User` struct:
```go
if (*u == charm.User{}) {
	return nil, errors.New("no user data received")
}
```