### PR TITLE
Show help for `charm fs`

### DIFF
--- a/cmd/fs.go
+++ b/cmd/fs.go
@@ -40,10 +40,6 @@ var (
 		Hidden: false,
 		Short:  "Use the Charm file system.",
 		Long:   paragraph("Commands to set, get and delete data from your Charm Cloud backed file system."),
-		Args:   cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
-		},
 	}
 
 	fsCatCmd = &cobra.Command{


### PR DESCRIPTION
When `charm fs` is run without arguments, let cobra display help rather than
exiting silently.

This is accomplished by removing the `RunE` property in the `Command` struct so
that cobra can display help correctly.

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/42545625/166131672-a3dbc258-4e31-4c1b-be4b-891068a3fe1e.png">
