### PR TITLE
Replaced deprecated ioutil package

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -325,7 +325,7 @@ func publicKeyAuthMethod(kp string) (ssh.AuthMethod, error) {
 	if err != nil {
 		return nil, err
 	}
-	key, err := ioutil.ReadFile(keyPath)
+	key, err := os.ReadFile(keyPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/backup_keys.go
+++ b/cmd/backup_keys.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -80,7 +79,7 @@ func validateDirectory(path string) error {
 			return fmt.Errorf("%v is not a directory, but it should be", path)
 		}
 
-		files, err := ioutil.ReadDir(path)
+		files, err := os.ReadDir(path)
 		if err != nil {
 			return err
 		}

--- a/fs/README.md
+++ b/fs/README.md
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"ioutil"
 	"os"
 
 	charmfs "github.com/charmbracelet/charm/fs"
@@ -24,7 +23,7 @@ func main() {
 	}
 	// Write a file
 	data := []byte("some data")
-	err = ioutil.WriteFile("/tmp/data", data, 0644)
+	err = os.WriteFile("/tmp/data", data, 0644)
 	if err != nil {
 		panic(err)
 	}

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -4,7 +4,6 @@ package kv
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"os"
@@ -153,7 +152,7 @@ func (kv *KV) Set(key []byte, value []byte) error {
 // SetReader is a convenience method to set the value for a key to the data
 // read from the provided io.Reader.
 func (kv *KV) SetReader(key []byte, value io.Reader) error {
-	v, err := ioutil.ReadAll(value)
+	v, err := io.ReadAll(value)
 	if err != nil {
 		return err
 	}

--- a/server/http.go
+++ b/server/http.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strconv"
@@ -203,7 +202,7 @@ func (s *HTTPServer) handlePostUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	u := &charm.User{}
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Printf("cannot read request body: %s", err)
 		s.renderError(w)
@@ -230,7 +229,7 @@ func (s *HTTPServer) handlePostUser(w http.ResponseWriter, r *http.Request) {
 func (s *HTTPServer) handlePostEncryptKey(w http.ResponseWriter, r *http.Request) {
 	u := s.charmUserFromRequest(w, r)
 	ek := &charm.EncryptKey{}
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Printf("cannot read request body: %s", err)
 		s.renderError(w)

--- a/server/storage/local/storage_test.go
+++ b/server/storage/local/storage_test.go
@@ -2,8 +2,8 @@ package localstorage
 
 import (
 	"bytes"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,7 +53,7 @@ func TestPut(t *testing.T) {
 			t.Fatalf("expected file %s to be a regular file", path)
 		}
 
-		read, err := ioutil.ReadAll(file)
+		read, err := io.ReadAll(file)
 		if err != nil {
 			t.Fatalf("expected no error when reading file %s", path)
 		}
@@ -86,7 +86,7 @@ func TestPut(t *testing.T) {
 			t.Fatalf("expected file %s to be a regular file", path)
 		}
 
-		read, err := ioutil.ReadAll(file)
+		read, err := io.ReadAll(file)
 		if err != nil {
 			t.Fatalf("expected no error when reading file %s", path)
 		}


### PR DESCRIPTION
Replaced use of deprecated ioutil functions with their correct ones.

More info why ioutil got deprecated: https://go.dev/doc/go1.16