### PR TITLE
feat: backup to stdout and other paths and import from stdin

### DIFF
--- a/cmd/backup_keys.go
+++ b/cmd/backup_keys.go
@@ -17,7 +17,7 @@ import (
 var backupOutputFile string
 
 func init() {
-	BackupKeysCmd.Flags().StringVarP(&backupOutputFile, "ouput", "o", "charm-keys-backup.tar", "keys backup filepath")
+	BackupKeysCmd.Flags().StringVarP(&backupOutputFile, "output", "o", "charm-keys-backup.tar", "keys backup filepath")
 }
 
 // BackupKeysCmd is the cobra.Command to back up a user's account SSH keys.
@@ -62,7 +62,7 @@ var BackupKeysCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			fmt.Print(string(bts))
+			_, _ = fmt.Fprint(cmd.OutOrStdout(), string(bts))
 			return nil
 		}
 

--- a/cmd/backup_keys.go
+++ b/cmd/backup_keys.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -14,6 +13,12 @@ import (
 	"github.com/charmbracelet/charm/client"
 	"github.com/spf13/cobra"
 )
+
+var backupOutputFile string
+
+func init() {
+	BackupKeysCmd.Flags().StringVarP(&backupOutputFile, "ouput", "o", "charm-keys-backup.tar", "keys backup filepath")
+}
 
 // BackupKeysCmd is the cobra.Command to back up a user's account SSH keys.
 var BackupKeysCmd = &cobra.Command{
@@ -24,20 +29,6 @@ var BackupKeysCmd = &cobra.Command{
 	Args:                  cobra.NoArgs,
 	DisableFlagsInUseLine: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		const filename = "charm-keys-backup.tar"
-
-		cwd, err := os.Getwd()
-		if err != nil {
-			return err
-		}
-
-		// Don't overwrite backup file
-		keyPath := path.Join(cwd, filename)
-		if fileOrDirectoryExists(keyPath) {
-			fmt.Printf("Not creating backup file: %s already exists.\n\n", code(filename))
-			os.Exit(1)
-		}
-
 		cfg, err := client.ConfigFromEnv()
 		if err != nil {
 			return err
@@ -57,11 +48,42 @@ var BackupKeysCmd = &cobra.Command{
 			return err
 		}
 
-		if err := createTar(dd, filename); err != nil {
+		backupPath := backupOutputFile
+		if backupPath == "-" {
+			exp := regexp.MustCompilePOSIX("charm_(rsa|ed25519)$")
+			paths, err := getKeyPaths(dd, exp)
+			if err != nil {
+				return err
+			}
+			if len(paths) != 1 {
+				return fmt.Errorf("backup to stdout only works with 1 key, you have %d", len(paths))
+			}
+			bts, err := os.ReadFile(paths[0])
+			if err != nil {
+				return err
+			}
+			fmt.Print(string(bts))
+			return nil
+		}
+
+		if !strings.HasSuffix(backupPath, ".tar") {
+			backupPath = backupPath + ".tar"
+		}
+
+		if fileOrDirectoryExists(backupPath) {
+			fmt.Printf("Not creating backup file: %s already exists.\n\n", code(backupPath))
+			os.Exit(1)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(backupPath), 0o754); err != nil {
 			return err
 		}
 
-		fmt.Printf("Done! Saved keys to %s.\n\n", code(filename))
+		if err := createTar(dd, backupPath); err != nil {
+			return err
+		}
+
+		fmt.Printf("Done! Saved keys to %s.\n\n", code(backupPath))
 		return nil
 	},
 }
@@ -128,49 +150,66 @@ func createTar(source string, target string) error {
 
 	exp := regexp.MustCompilePOSIX("charm_(rsa|ed25519)(.pub)?$")
 
-	if err := filepath.Walk(source,
-		func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-
-			if !exp.MatchString(path) {
-				return nil
-			}
-
-			header, err := tar.FileInfoHeader(info, info.Name())
-			if err != nil {
-				return err
-			}
-
-			if baseDir != "" {
-				header.Name = filepath.Join(baseDir, strings.TrimPrefix(path, source))
-			}
-
-			if err := tarball.WriteHeader(header); err != nil {
-				return err
-			}
-
-			if info.IsDir() {
-				return nil
-			}
-
-			file, err := os.Open(path)
-			if err != nil {
-				return err
-			}
-			defer file.Close() // nolint:errcheck
-
-			if _, err := io.Copy(tarball, file); err != nil {
-				return err
-			}
-			return file.Close()
-		}); err != nil {
+	paths, err := getKeyPaths(source, exp)
+	if err != nil {
 		return err
+	}
+
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+
+		header, err := tar.FileInfoHeader(info, info.Name())
+		if err != nil {
+			return err
+		}
+
+		if baseDir != "" {
+			header.Name = filepath.Join(baseDir, strings.TrimPrefix(path, source))
+		}
+
+		if err := tarball.WriteHeader(header); err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close() // nolint:errcheck
+
+		if _, err := io.Copy(tarball, file); err != nil {
+			return err
+		}
+		if err := file.Close(); err != nil {
+			return err
+		}
 	}
 
 	if err := tarball.Close(); err != nil {
 		return err
 	}
 	return tarfile.Close()
+}
+
+func getKeyPaths(source string, filter *regexp.Regexp) ([]string, error) {
+	var result []string
+	err := filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if filter.MatchString(path) {
+			result = append(result, path)
+		}
+
+		return nil
+	})
+	return result, err
 }

--- a/cmd/backup_keys_test.go
+++ b/cmd/backup_keys_test.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"archive/tar"
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/charmbracelet/charm/testserver"
+	"golang.org/x/crypto/ssh"
 )
 
 func TestBackupKeysCmd(t *testing.T) {
@@ -53,5 +55,20 @@ func TestBackupKeysCmd(t *testing.T) {
 
 	if len(paths) != 2 {
 		t.Errorf("expected at least 2 files (public and private keys), got %d: %v", len(paths), paths)
+	}
+}
+
+func TestBackupToStdout(t *testing.T) {
+	_ = testserver.SetupTestServer(t)
+	var b bytes.Buffer
+
+	BackupKeysCmd.SetArgs([]string{"-o", "-"})
+	BackupKeysCmd.SetOut(&b)
+	if err := BackupKeysCmd.Execute(); err != nil {
+		t.Fatalf("command failed: %s", err)
+	}
+
+	if _, err := ssh.ParsePrivateKey(b.Bytes()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
 }

--- a/cmd/import_keys.go
+++ b/cmd/import_keys.go
@@ -203,15 +203,19 @@ func restoreFromStdin(dd string) error {
 		return fmt.Errorf("invalid private key: %w", err)
 	}
 
+	if signer.PublicKey().Type() != "ssh-ed25519" {
+		return fmt.Errorf("only ed25519 keys are allowed, yours is %s", signer.PublicKey().Type())
+	}
+
 	keypath := filepath.Join(dd, "charm_ed25519")
-	if err := os.WriteFile(keypath, bts, 0o640); err != nil {
+	if err := os.WriteFile(keypath, bts, 0o600); err != nil {
 		return err
 	}
 
 	if err := os.WriteFile(
 		keypath+".pub",
 		ssh.MarshalAuthorizedKey(signer.PublicKey()),
-		0o644,
+		0o600,
 	); err != nil {
 		return err
 	}

--- a/cmd/import_keys_test.go
+++ b/cmd/import_keys_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charmbracelet/charm/testserver"
+)
+
+func TestImportKeysFromStdin(t *testing.T) {
+	c := testserver.SetupTestServer(t)
+
+	var r bytes.Buffer
+	BackupKeysCmd.SetArgs([]string{"-o", "-"})
+	BackupKeysCmd.SetOut(&r)
+	if err := BackupKeysCmd.Execute(); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	dd, _ := c.DataPath()
+	if err := os.RemoveAll(dd); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	ImportKeysCmd.SetIn(&r)
+	ImportKeysCmd.SetArgs([]string{"-f", "-"})
+	if err := ImportKeysCmd.Execute(); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if _, err := os.Stat(filepath.Join(dd, "charm_ed25519")); err != nil {
+		t.Fatalf(err.Error())
+	}
+	if _, err := os.Stat(filepath.Join(dd, "charm_ed25519.pub")); err != nil {
+		t.Fatalf(err.Error())
+	}
+}
+
+func TestImportKeysFromFile(t *testing.T) {
+	c := testserver.SetupTestServer(t)
+
+	f := filepath.Join(t.TempDir(), "backup.tar")
+
+	BackupKeysCmd.SetArgs([]string{"-o", f})
+	if err := BackupKeysCmd.Execute(); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	dd, _ := c.DataPath()
+	if err := os.RemoveAll(dd); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	ImportKeysCmd.SetArgs([]string{"-f", f})
+	if err := ImportKeysCmd.Execute(); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if _, err := os.Stat(filepath.Join(dd, "charm_ed25519")); err != nil {
+		t.Fatalf(err.Error())
+	}
+	if _, err := os.Stat(filepath.Join(dd, "charm_ed25519.pub")); err != nil {
+		t.Fatalf(err.Error())
+	}
+}

--- a/docs/backup-account.md
+++ b/docs/backup-account.md
@@ -1,0 +1,34 @@
+# Backing up your account
+
+When you first run `charm`, it creates a new ED25519 key pair for you.
+That private key is the __key__ to your data.
+
+To back it up, you can use the `backup-keys` command, as such:
+
+```shell
+charm backup-keys
+```
+
+It'll create a `charm-keys-backup.tar` file in the current folder.
+You can override the path by passing a `-o` flag, as such:
+
+```shell
+charm backup-keys -o ~/charm.tar
+```
+
+You may also print the private key to STDOUT in order to pipe it into other command, such as [`melt`](https://github.com/charmbracelet/melt).
+Example usage:
+
+```shell
+charm backup-keys -o - | melt
+```
+
+## Restoring from a backup
+
+To restore your account, you can use the `import-keys` command:
+
+```shell
+charm import-keys charm-keys-backup.tar
+```
+
+TODO: import from STDIN

--- a/docs/backup-account.md
+++ b/docs/backup-account.md
@@ -23,12 +23,4 @@ Example usage:
 charm backup-keys -o - | melt
 ```
 
-## Restoring from a backup
-
-To restore your account, you can use the `import-keys` command:
-
-```shell
-charm import-keys charm-keys-backup.tar
-```
-
-TODO: import from STDIN
+Also worth reading [./docs/restore-account.md](./docs/restore-account.md).

--- a/docs/restore-account.md
+++ b/docs/restore-account.md
@@ -1,0 +1,15 @@
+# Restoring from a backup
+
+To restore your account, you can use the `import-keys` command:
+
+```shell
+charm import-keys charm-keys-backup.tar
+```
+
+You can also import a private key from STDIN from another tool, such as [melt](https://github.com/charmbracelet/melt):
+
+```shell
+cat seed.txt | melt restore - | charm import-keys
+```
+
+Also worth reading [./docs/backup-account.md](./docs/backup-account.md).


### PR DESCRIPTION
- adds a `-o` flag to `backup-keys`, so users can backup to any filepath 
- `-o -` prints only the private key to stdout, so it can be pipes to other things, e.g. melt
- allow to restore keys from stdin

closes #128 
closes https://github.com/charmbracelet/charm/issues/116
closes https://github.com/charmbracelet/melt/pull/17
refs https://github.com/charmbracelet/melt/pull/18