### PR TITLE
fix: use a noop stats implementation if stats are disabled

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/charm/server/db"
 	"github.com/charmbracelet/charm/server/db/sqlite"
 	"github.com/charmbracelet/charm/server/stats"
+	"github.com/charmbracelet/charm/server/stats/noop"
 	"github.com/charmbracelet/charm/server/stats/prometheus"
 	"github.com/charmbracelet/charm/server/storage"
 	lfs "github.com/charmbracelet/charm/server/storage/local"
@@ -189,8 +190,7 @@ func (srv *Server) Close() error {
 		return fmt.Errorf("db close error: %s", err)
 	}
 	if srv.Config.Stats != nil {
-		err := srv.Config.Stats.Close()
-		if err != nil {
+		if err := srv.Config.Stats.Close(); err != nil {
 			return fmt.Errorf("db close error: %s", err)
 		}
 	}
@@ -216,5 +216,8 @@ func (srv *Server) init(cfg *Config) {
 	}
 	if cfg.EnableMetrics && cfg.Stats == nil {
 		srv.Config = cfg.WithStats(prometheus.NewStats(cfg.DB, cfg.StatsPort))
+	}
+	if cfg.Stats == nil {
+		srv.Config = cfg.WithStats(noop.Stats{})
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -214,10 +214,14 @@ func (srv *Server) init(cfg *Config) {
 		}
 		srv.Config = cfg.WithFileStore(fs)
 	}
-	if cfg.EnableMetrics && cfg.Stats == nil {
-		srv.Config = cfg.WithStats(prometheus.NewStats(cfg.DB, cfg.StatsPort))
-	}
 	if cfg.Stats == nil {
-		srv.Config = cfg.WithStats(noop.Stats{})
+		srv.Config = cfg.WithStats(getStatsImpl(cfg))
 	}
+}
+
+func getStatsImpl(cfg *Config) stats.Stats {
+	if cfg.EnableMetrics {
+		return prometheus.NewStats(cfg.DB, cfg.StatsPort)
+	}
+	return noop.Stats{}
 }

--- a/server/stats/noop/noop.go
+++ b/server/stats/noop/noop.go
@@ -1,0 +1,34 @@
+// Package noop provides a stats impl that does nothing.
+// nolint:revive
+package noop
+
+import (
+	"context"
+
+	"github.com/charmbracelet/charm/server/stats"
+)
+
+// Stats is a stats implementation that does nothing.
+type Stats struct{}
+
+var _ stats.Stats = Stats{}
+
+func (Stats) APILinkGen()                      {}
+func (Stats) APILinkRequest()                  {}
+func (Stats) APIUnlink()                       {}
+func (Stats) APIAuth()                         {}
+func (Stats) APIKeys()                         {}
+func (Stats) LinkGen()                         {}
+func (Stats) LinkRequest()                     {}
+func (Stats) Keys()                            {}
+func (Stats) ID()                              {}
+func (Stats) JWT()                             {}
+func (Stats) GetUserByID()                     {}
+func (Stats) GetUser()                         {}
+func (Stats) SetUserName()                     {}
+func (Stats) GetNewsList()                     {}
+func (Stats) GetNews()                         {}
+func (Stats) PostNews()                        {}
+func (Stats) Start() error                     { return nil }
+func (Stats) Close() error                     { return nil }
+func (Stats) Shutdown(_ context.Context) error { return nil }

--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -1,7 +1,6 @@
 package testserver
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -14,7 +13,6 @@ import (
 
 	"github.com/charmbracelet/charm/client"
 	"github.com/charmbracelet/charm/server"
-	"github.com/charmbracelet/charm/server/stats"
 	"github.com/charmbracelet/keygen"
 )
 
@@ -41,7 +39,7 @@ func SetupTestServer(tb testing.TB) *client.Client {
 		tb.Fatalf("keygen error: %s", err)
 	}
 
-	cfg = cfg.WithKeys(kp.PublicKey(), kp.PrivateKeyPEM()).WithStats(noopStats{})
+	cfg = cfg.WithKeys(kp.PublicKey(), kp.PrivateKeyPEM())
 	s, err := server.NewServer(cfg)
 	if err != nil {
 		tb.Fatalf("new server error: %s", err)
@@ -116,28 +114,3 @@ func randomPort(tb testing.TB) int {
 	p, _ := strconv.Atoi(addr[strings.LastIndex(addr, ":")+1:])
 	return p
 }
-
-type noopStats struct{}
-
-var _ stats.Stats = noopStats{}
-
-func (noopStats) APILinkGen()     {}
-func (noopStats) APILinkRequest() {}
-func (noopStats) APIUnlink()      {}
-func (noopStats) APIAuth()        {}
-func (noopStats) APIKeys()        {}
-func (noopStats) LinkGen()        {}
-func (noopStats) LinkRequest()    {}
-func (noopStats) Keys()           {}
-func (noopStats) ID()             {}
-func (noopStats) JWT()            {}
-func (noopStats) GetUserByID()    {}
-func (noopStats) GetUser()        {}
-func (noopStats) SetUserName()    {}
-func (noopStats) GetNewsList()    {}
-func (noopStats) GetNews()        {}
-func (noopStats) PostNews()       {}
-func (noopStats) Start() error    { return nil }
-func (noopStats) Close() error    { return nil }
-
-func (noopStats) Shutdown(_ context.Context) error { return nil }

--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -1,6 +1,7 @@
 package testserver
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/charmbracelet/charm/client"
 	"github.com/charmbracelet/charm/server"
+	"github.com/charmbracelet/charm/server/stats"
 	"github.com/charmbracelet/keygen"
 )
 
@@ -39,7 +41,7 @@ func SetupTestServer(tb testing.TB) *client.Client {
 		tb.Fatalf("keygen error: %s", err)
 	}
 
-	cfg = cfg.WithKeys(kp.PublicKey(), kp.PrivateKeyPEM())
+	cfg = cfg.WithKeys(kp.PublicKey(), kp.PrivateKeyPEM()).WithStats(noopStats{})
 	s, err := server.NewServer(cfg)
 	if err != nil {
 		tb.Fatalf("new server error: %s", err)
@@ -107,10 +109,35 @@ func randomPort(tb testing.TB) int {
 	if err != nil {
 		tb.Fatalf("could not get a random port: %s", err)
 	}
-	listener.Close()
+	listener.Close() //nolint:errcheck
 
 	addr := listener.Addr().String()
 
 	p, _ := strconv.Atoi(addr[strings.LastIndex(addr, ":")+1:])
 	return p
 }
+
+type noopStats struct{}
+
+var _ stats.Stats = noopStats{}
+
+func (noopStats) APILinkGen()     {}
+func (noopStats) APILinkRequest() {}
+func (noopStats) APIUnlink()      {}
+func (noopStats) APIAuth()        {}
+func (noopStats) APIKeys()        {}
+func (noopStats) LinkGen()        {}
+func (noopStats) LinkRequest()    {}
+func (noopStats) Keys()           {}
+func (noopStats) ID()             {}
+func (noopStats) JWT()            {}
+func (noopStats) GetUserByID()    {}
+func (noopStats) GetUser()        {}
+func (noopStats) SetUserName()    {}
+func (noopStats) GetNewsList()    {}
+func (noopStats) GetNews()        {}
+func (noopStats) PostNews()       {}
+func (noopStats) Start() error    { return nil }
+func (noopStats) Close() error    { return nil }
+
+func (noopStats) Shutdown(_ context.Context) error { return nil }


### PR DESCRIPTION
otherwise `cfg.Stats` will be nil and metered endpoints will fail - including tests