### PR TITLE
fixed: proper way to handle context values

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -405,10 +405,10 @@ func (s *HTTPServer) handleGetNews(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *HTTPServer) charmUserFromRequest(w http.ResponseWriter, r *http.Request) *charm.User {
-	u := r.Context().Value(ctxUserKey)
-	if u == nil {
+	u, ok := r.Context().Value(ctxUserKey).(*charm.User)
+	if !ok {
 		log.Printf("could not assign user to request context")
 		s.renderError(w)
 	}
-	return u.(*charm.User)
+	return u
 }

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -16,8 +16,8 @@ import (
 type contextKey string
 
 var (
-	ctxUserKey contextKey = "charmUser"
-	ctxPublic  contextKey = "public"
+	ctxUserKey   contextKey = "charmUser"
+	ctxPublicKey contextKey = "public"
 )
 
 // MaxFSRequestSize is the maximum size of a request body for fs endpoints.
@@ -56,7 +56,7 @@ func PublicPrefixesMiddleware(prefixes []string) func(http.Handler) http.Handler
 					public = true
 				}
 			}
-			ctx := context.WithValue(r.Context(), ctxPublic, public)
+			ctx := context.WithValue(r.Context(), ctxPublicKey, public)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
@@ -111,7 +111,7 @@ func CharmUserMiddleware(s *HTTPServer) func(http.Handler) http.Handler {
 }
 
 func isPublic(r *http.Request) bool {
-	public, ok := r.Context().Value(ctxPublic).(bool)
+	public, ok := r.Context().Value(ctxPublicKey).(bool)
 	if !ok {
 		log.Print("cannot get public value from context")
 		return false

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -14,11 +14,10 @@ import (
 )
 
 type contextKey string
-type contextPublic string
 
 var (
-	ctxUserKey contextKey    = "charmUser"
-	ctxPublic  contextPublic = "public"
+	ctxUserKey contextKey = "charmUser"
+	ctxPublic  contextKey = "public"
 )
 
 // MaxFSRequestSize is the maximum size of a request body for fs endpoints.


### PR DESCRIPTION
Fixed the issue with context values - `staticcheck: SA1029 - Inappropriate key in call to context.WithValue` in `middleware.go`.

And in the second file `http.go` added proper way to assert the type of a context value.