### PR TITLE
fix: fail early on invalid key types

### DIFF
--- a/ui/charmclient/client.go
+++ b/ui/charmclient/client.go
@@ -1,6 +1,8 @@
 package charmclient
 
 import (
+	"log"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/charm/client"
 	charm "github.com/charmbracelet/charm/proto"
@@ -25,6 +27,7 @@ type ErrMsg struct {
 func NewClient(cfg *client.Config) tea.Cmd {
 	return func() tea.Msg {
 		cc, err := client.NewClient(cfg)
+		log.Println("error:", err)
 
 		if err == charm.ErrMissingSSHAuth {
 			return SSHAuthErrorMsg{err}

--- a/ui/charmclient/client.go
+++ b/ui/charmclient/client.go
@@ -1,8 +1,6 @@
 package charmclient
 
 import (
-	"log"
-
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/charm/client"
 	charm "github.com/charmbracelet/charm/proto"
@@ -27,7 +25,6 @@ type ErrMsg struct {
 func NewClient(cfg *client.Config) tea.Cmd {
 	return func() tea.Msg {
 		cc, err := client.NewClient(cfg)
-		log.Println("error:", err)
 
 		if err == charm.ErrMissingSSHAuth {
 			return SSHAuthErrorMsg{err}


### PR DESCRIPTION
Fail early to avoid breaking things (namely anything involving signing) later.


<img width="725" alt="CleanShot 2022-05-12 at 11 36 12@2x" src="https://user-images.githubusercontent.com/245435/168100565-55ab2992-7159-42e8-a250-ca9623308631.png">
