### PR TITLE
feat: output data dir with charm where

### DIFF
--- a/cmd/where.go
+++ b/cmd/where.go
@@ -7,16 +7,16 @@ import (
 )
 
 var WhereCmd = &cobra.Command{
-	Use: "where",
+	Use:   "where",
 	Short: "Find where your cloud.charm.sh folder resides on your machine",
-	Long: paragraph("Find the absolute path to your charm keys, databases, etc."),
+	Long:  paragraph("Find the absolute path to your charm keys, databases, etc."),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cc := initCharmClient()
 		path, err := cc.DataPath()
 		if err != nil {
 			return err
 		}
-		fmt.Fprint(cmd.OutOrStdout(), path)
+		fmt.Fprintln(cmd.OutOrStdout(), path)
 		return nil
 	},
 }

--- a/cmd/where.go
+++ b/cmd/where.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var WhereCmd = &cobra.Command{
+	Use: "where",
+	Short: "Find where your cloud.charm.sh folder resides on your machine",
+	Long: paragraph("Find the absolute path to your charm keys, databases, etc."),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cc := initCharmClient()
+		path, err := cc.DataPath()
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(cmd.OutOrStdout(), path)
+		return nil
+	},
+}

--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func init() {
 		cmd.FSCmd,
 		cmd.CryptCmd,
 		cmd.MigrateAccountCmd,
+		cmd.WhereCmd,
 		manCmd,
 	)
 }


### PR DESCRIPTION
## Changes:
- [x] add cobra command for `where` to get the data directory on the user's machine

## Related Issues:
#151 

## Other:
Example output:
![output](https://user-images.githubusercontent.com/15822994/177646562-25bcac0b-a80b-4bba-8459-d7e908e39b54.png)
