### PR TITLE
Pre-populate username

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -194,7 +194,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Initialize models that require a Charm client
 		m.info = info.NewModel(m.cc)
-		m.username = username.NewModel(m.cc)
+		m.username = username.NewModel(m.cc, "")
 		m.keys = keys.NewModel(m.cfg)
 		m.keys.SetCharmClient(m.cc)
 
@@ -210,7 +210,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case username.NameSetMsg:
 		m.status = statusReady
-		m.username = username.NewModel(m.cc) // reset the state
+		m.username = username.NewModel(m.cc, "") // reset the state
 		m.info.User.Name = string(msg)
 	}
 
@@ -277,7 +277,7 @@ func updateChilden(msg tea.Msg, m model) (model, tea.Cmd) {
 	case statusSettingUsername:
 		m.username, cmd = username.Update(msg, m.username)
 		if m.username.Done {
-			m.username = username.NewModel(m.cc) // reset the state
+			m.username = username.NewModel(m.cc, "") // reset the state
 			m.status = statusReady
 		} else if m.username.Quit {
 			m.status = statusQuitting

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -194,7 +194,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Initialize models that require a Charm client
 		m.info = info.NewModel(m.cc)
-		m.username = username.NewModel(m.cc, "")
+		m.username = username.NewModel(m.cc)
 		m.keys = keys.NewModel(m.cfg)
 		m.keys.SetCharmClient(m.cc)
 
@@ -210,7 +210,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case username.NameSetMsg:
 		m.status = statusReady
-		m.username = username.NewModel(m.cc, "") // reset the state
+		m.username = username.NewModel(m.cc) // reset the state
 		m.info.User.Name = string(msg)
 	}
 
@@ -277,7 +277,7 @@ func updateChilden(msg tea.Msg, m model) (model, tea.Cmd) {
 	case statusSettingUsername:
 		m.username, cmd = username.Update(msg, m.username)
 		if m.username.Done {
-			m.username = username.NewModel(m.cc, "") // reset the state
+			m.username = username.NewModel(m.cc) // reset the state
 			m.status = statusReady
 		} else if m.username.Quit {
 			m.status = statusQuitting

--- a/ui/username/username.go
+++ b/ui/username/username.go
@@ -89,15 +89,24 @@ func (m *Model) indexBackward() {
 }
 
 // NewModel returns a new username model in its initial state.
-func NewModel(cc *client.Client) Model {
+func NewModel(cc *client.Client, username string) Model {
 	st := common.DefaultStyles()
 
 	im := input.NewModel()
 	im.CursorStyle = st.Cursor
-	im.Placeholder = "divagurl2000"
 	im.Prompt = st.FocusedPrompt.String()
 	im.CharLimit = 50
 	im.Focus()
+
+	im.Placeholder = username
+
+	if len(im.Placeholder) == 0 {
+		im.Placeholder = "divagurl2000"
+
+		if u, err := cc.Bio(); err == nil && u.Name != "" {
+			im.Placeholder = u.Name
+		}
+	}
 
 	return Model{
 		Done:    false,
@@ -116,7 +125,7 @@ func NewModel(cc *client.Client) Model {
 // Init is the Bubble Tea initialization function.
 func Init(cc *client.Client) func() (Model, tea.Cmd) {
 	return func() (Model, tea.Cmd) {
-		m := NewModel(cc)
+		m := NewModel(cc, "")
 		return m, InitialCmd()
 	}
 }

--- a/ui/username/username.go
+++ b/ui/username/username.go
@@ -89,7 +89,7 @@ func (m *Model) indexBackward() {
 }
 
 // NewModel returns a new username model in its initial state.
-func NewModel(cc *client.Client, username string) Model {
+func NewModel(cc *client.Client) Model {
 	st := common.DefaultStyles()
 
 	im := input.NewModel()
@@ -98,14 +98,9 @@ func NewModel(cc *client.Client, username string) Model {
 	im.CharLimit = 50
 	im.Focus()
 
-	im.Placeholder = username
-
-	if len(im.Placeholder) == 0 {
-		im.Placeholder = "divagurl2000"
-
-		if u, err := cc.Bio(); err == nil && u.Name != "" {
-			im.Placeholder = u.Name
-		}
+	im.Placeholder = "divagurl2000"
+	if u, err := cc.Bio(); err == nil && u.Name != "" {
+		im.Placeholder = u.Name
 	}
 
 	return Model{
@@ -125,7 +120,7 @@ func NewModel(cc *client.Client, username string) Model {
 // Init is the Bubble Tea initialization function.
 func Init(cc *client.Client) func() (Model, tea.Cmd) {
 	return func() (Model, tea.Cmd) {
-		m := NewModel(cc, "")
+		m := NewModel(cc)
 		return m, InitialCmd()
 	}
 }


### PR DESCRIPTION
If a username is set, charm now pre-populates the input field with it in the "set username" section. Resolves #16.

I tried to incorporate some of the feedback given in https://github.com/charmbracelet/charm/pull/17#issuecomment-751406322 but I'm new to bubble tea.