### PR TITLE
Change brew command

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Use a package manager:
 
 ```bash
 # macOS or Linux
-brew tap charmbracelet/tap && brew install charmbracelet/tap/charm
+brew install charmbracelet/tap/charm
 
 # Arch Linux (btw)
 pacman -S charm


### PR DESCRIPTION
You don't need to run `brew tap` if you specify a repository when installing.